### PR TITLE
Comment the copy command of chart--helm

### DIFF
--- a/install/docker/gitpod-image/Dockerfile
+++ b/install/docker/gitpod-image/Dockerfile
@@ -18,7 +18,8 @@ VOLUME /var/gitpod/workspaces
 COPY gitpod-helm-installer.yaml /var/lib/rancher/k3s/server/manifests/
 COPY persistent-volumes.yaml /var/lib/rancher/k3s/server/manifests/
 COPY values.yaml /default_values/01_values.yaml
-COPY chart--helm/gitpod /chart
+#COPY chart--helm/gitpod /chart
+
 
 COPY entrypoint.sh /entrypoint
 


### PR DESCRIPTION
There is no such file or directory chart--helm which the Dockerfile is copying in the docker image.
![Screenshot from 2020-12-03 10-53-04](https://user-images.githubusercontent.com/65770246/100967648-c0ea3980-3555-11eb-8317-e3e320c05de9.png)


